### PR TITLE
chore: configure Renovate (TECH-1201)

### DIFF
--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -1,0 +1,45 @@
+name: Add changeset to Renovate PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  changeset:
+    name: Add changeset
+    # Only run on Renovate's own branches, excluding lock-file maintenance
+    # (those only touch pnpm-lock.yaml, which isn't published, so no release is needed)
+    if: ${{ github.actor == 'renovate[bot]' && startsWith(github.head_ref, 'renovate/') && github.head_ref != 'renovate/lock-file-maintenance' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Add patch changeset if missing
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Skip if the PR already contains a changeset (any .md besides README)
+          if find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "Changeset already present — nothing to do."
+            exit 0
+          fi
+          file=".changeset/renovate-${{ github.event.pull_request.number }}.md"
+          {
+            echo '---'
+            echo '"@inato/custom-instrumentations-node": patch'
+            echo '---'
+            echo
+            echo "${PR_TITLE:-Update dependencies}"
+          } > "$file"
+
+      - name: Commit changeset
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: add changeset for dependency update"
+          file_pattern: ".changeset/*.md"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 6am on monday"],
+  "rangeStrategy": "pin",
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group all OpenTelemetry packages so they bump in lockstep",
+      "matchPackageNames": ["@opentelemetry/**"],
+      "groupName": "opentelemetry packages"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Keep pnpm version in sync with packageManager field",
+      "matchDepNames": ["pnpm"],
+      "matchManagers": ["npm"],
+      "rangeStrategy": "pin"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  }
+}


### PR DESCRIPTION
## What

Sets up [Renovate](https://docs.renovatebot.com/) for automated dependency updates, plus a workflow to bridge Renovate and our changesets-based release flow.

### `renovate.json`
- **Pins exact versions** (`rangeStrategy: pin`) — matches how `package.json` already pins deps with no `^`.
- **Groups all `@opentelemetry/*` packages** into one PR so they bump in lockstep (mirrors past "Bump opentelemetry packages" commits).
- **Groups GitHub Actions** updates into a single PR.
- Dependency Dashboard issue, semantic commits, weekly schedule (Mon before 6am, Europe/Paris), and weekly lockfile maintenance.
- npm, github-actions, and Dockerfile managers are auto-detected (covers the Dockerfile base image and the `pnpm` `packageManager` field).

### `.github/workflows/renovate-changeset.yml`
Releases go through `changesets/action`, and Renovate doesn't create changesets — so dependency PRs wouldn't otherwise trigger a version bump/publish. This workflow, on each Renovate PR:
- Guards on `renovate[bot]` + branch prefix, and **skips `renovate/lock-file-maintenance`** (lockfile-only, nothing published).
- Skips if a changeset already exists (so re-runs don't duplicate).
- Otherwise writes a `patch` changeset for `@inato/custom-instrumentations-node` (PR title as summary) and commits it back to the PR branch via `git-auto-commit-action`.

## Note
This config only takes effect once the **Renovate GitHub App is installed** on the repo (org-admin action) — it can't be enabled from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)