### PR TITLE
chore: limit Renovate to security fixes only (TECH-1201)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,33 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits"
+    ":dependencyDashboard"
   ],
   "timezone": "Europe/Paris",
-  "schedule": ["before 6am on monday"],
   "rangeStrategy": "pin",
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "description": "Group all OpenTelemetry packages so they bump in lockstep",
-      "matchPackageNames": ["@opentelemetry/**"],
-      "groupName": "opentelemetry packages"
-    },
-    {
-      "description": "Group GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "github-actions"
-    },
-    {
-      "description": "Keep pnpm version in sync with packageManager field",
-      "matchDepNames": ["pnpm"],
-      "matchManagers": ["npm"],
-      "rangeStrategy": "pin"
+      "description": "Disable all routine updates — only security fixes raise PRs",
+      "matchPackageNames": ["*"],
+      "enabled": false
     }
   ],
-  "lockFileMaintenance": {
+  "vulnerabilityAlerts": {
     "enabled": true,
-    "schedule": ["before 6am on monday"]
-  }
+    "labels": ["security"]
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
## What

Follow-up to #18. Renovate's routine update PRs were overwhelming, so this switches it to **security-only**: no routine dependency PRs, only vulnerability-driven ones.

## Changes to `renovate.json`
- **Disable all routine updates** via a `matchPackageNames: ["*"]` rule with `enabled: false`.
- **`vulnerabilityAlerts.enabled: true`** — the one path Renovate honors even for disabled packages, so only known vulnerabilities raise PRs (labeled `security`).
- **`osvVulnerabilityAlerts: true`** broadens detection beyond GitHub advisories to the OSV database.
- Dropped the weekly schedule (security fixes should land ASAP, not batched) and the lockfile-maintenance / grouping / pinning rules (only relevant to routine updates). Kept the Dependency Dashboard.

## Prerequisite
Renovate reads vulnerability data from **GitHub Dependabot alerts**, so these must be enabled or the config stays silent:
Repo → Settings → Code security → **Dependency graph** + **Dependabot alerts**.

The changeset auto-add workflow still applies to security PRs (they're still `renovate/...` branches), so a vuln fix still gets a changeset and publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)